### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/fauxton/ember-addon-state-bucket.git",
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
Since it wasn't specified, NPM is picking up the first Github URL in the README and treating that as this package's repository (which means it's getting listed with node-persist's repo).